### PR TITLE
add handshakeTimeout parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -199,7 +199,7 @@ var glbScpServer *SCPServer
 var glbLocalConnProvider *LocalConnProvider
 
 var (
-	optProtocol = 0
+	optProtocol        = 0
 	optUploadMinPacket int
 	optUploadMaxDelay  int
 )
@@ -361,15 +361,15 @@ func main() {
 	go handleSignal()
 
 	glbScpServer = NewSCPServer(&Options{
-		reuseTimeout:   reuseTimeout,
-        handshakeTimeout: handshakeTimeout,
-		tcpOptions: &tcp,
-		kcpOptions: &kcp,
+		reuseTimeout:     reuseTimeout,
+		handshakeTimeout: handshakeTimeout,
+		tcpOptions:       &tcp,
+		kcpOptions:       &kcp,
 	})
 
 	var wg sync.WaitGroup
 
-	if optProtocol == 0 || optProtocol & TCP != 0 {
+	if optProtocol == 0 || optProtocol&TCP != 0 {
 		wg.Add(1)
 		go func() {
 			Log("tcp options: %v", tcp)
@@ -377,7 +377,7 @@ func main() {
 			wg.Done()
 		}()
 	}
-	if optProtocol & KCP != 0 {
+	if optProtocol&KCP != 0 {
 		wg.Add(1)
 		go func() {
 			Log("kcp options: %v", kcp)

--- a/main.go
+++ b/main.go
@@ -326,6 +326,7 @@ func main() {
 	var config string
 	var listen string
 	var reuseTimeout int
+	var handshakeTimeout int
 	var sentCacheSize int
 
 	flag.Var(&tcp, "tcp", "tcp options, use default by setting empty literal")
@@ -334,6 +335,7 @@ func main() {
 	flag.StringVar(&listen, "listen", "0.0.0.0:1248", "local listen port(0.0.0.0:1248)")
 	flag.IntVar(&logLevel, "log", 2, "larger value for detail log")
 	flag.IntVar(&reuseTimeout, "reuseTimeout", 30, "reuse timeout")
+	flag.IntVar(&handshakeTimeout, "handshakeTimeout", 30, "handshake stage timeout")
 	flag.IntVar(&sentCacheSize, "sbuf", 65536, "sent cache size")
 	flag.IntVar(&optUploadMinPacket, "uploadMinPacket", 0, "upload minimal packet")
 	flag.IntVar(&optUploadMaxDelay, "uploadMaxDelay", 0, "upload maximal delay milliseconds")
@@ -360,7 +362,7 @@ func main() {
 
 	glbScpServer = NewSCPServer(&Options{
 		reuseTimeout:   reuseTimeout,
-
+        handshakeTimeout: handshakeTimeout,
 		tcpOptions: &tcp,
 		kcpOptions: &kcp,
 	})

--- a/net.go
+++ b/net.go
@@ -34,10 +34,10 @@ type (
 	}
 
 	Options struct {
-		reuseTimeout int
+		reuseTimeout     int
 		handshakeTimeout int
-		tcpOptions    *TcpOptions
-		kcpOptions    *KcpOptions
+		tcpOptions       *TcpOptions
+		kcpOptions       *KcpOptions
 	}
 
 	tcpListener struct {
@@ -54,12 +54,12 @@ type (
 
 	tcpConn struct {
 		*net.TCPConn
-		readTimeout    time.Duration
+		readTimeout time.Duration
 	}
 
 	kcpConn struct {
 		*kcp.UDPSession
-		readTimeout    time.Duration
+		readTimeout time.Duration
 	}
 )
 

--- a/net.go
+++ b/net.go
@@ -35,6 +35,7 @@ type (
 
 	Options struct {
 		reuseTimeout int
+		handshakeTimeout int
 		tcpOptions    *TcpOptions
 		kcpOptions    *KcpOptions
 	}

--- a/scp/scp.go
+++ b/scp/scp.go
@@ -3,6 +3,7 @@ package scp
 
 import (
 	"net"
+	"time"
 )
 
 type SCPServer interface {
@@ -17,6 +18,8 @@ type SCPServer interface {
 
 	// close a conneciton by id
 	CloseByID(id int) *Conn
+
+	HandshakeTimeout() time.Duration
 }
 
 type Config struct {

--- a/server.go
+++ b/server.go
@@ -126,10 +126,10 @@ func (p *ConnPair) Pump() {
 }
 
 type SCPServer struct {
-	options      *Options
-	reuseTimeout time.Duration
+	options          *Options
+	reuseTimeout     time.Duration
 	handshakeTimeout time.Duration
-	idAllocator  *scp.IDAllocator
+	idAllocator      *scp.IDAllocator
 
 	connPairMutex sync.Mutex
 	connPairs     map[int]*ConnPair
@@ -279,10 +279,10 @@ func (ss *SCPServer) Start(network, laddr string) error {
 
 func NewSCPServer(options *Options) *SCPServer {
 	return &SCPServer{
-		options:      options,
-		reuseTimeout: time.Duration(options.reuseTimeout) * time.Second,
+		options:          options,
+		reuseTimeout:     time.Duration(options.reuseTimeout) * time.Second,
 		handshakeTimeout: time.Duration(options.handshakeTimeout) * time.Second,
-		idAllocator:  scp.NewIDAllocator(1),
-		connPairs:    make(map[int]*ConnPair),
+		idAllocator:      scp.NewIDAllocator(1),
+		connPairs:        make(map[int]*ConnPair),
 	}
 }

--- a/server.go
+++ b/server.go
@@ -128,6 +128,7 @@ func (p *ConnPair) Pump() {
 type SCPServer struct {
 	options      *Options
 	reuseTimeout time.Duration
+	handshakeTimeout time.Duration
 	idAllocator  *scp.IDAllocator
 
 	connPairMutex sync.Mutex
@@ -140,6 +141,10 @@ func (ss *SCPServer) AcquireID() int {
 
 func (ss *SCPServer) ReleaseID(id int) {
 	ss.idAllocator.ReleaseID(id)
+}
+
+func (ss *SCPServer) HandshakeTimeout() time.Duration {
+	return ss.handshakeTimeout
 }
 
 func (ss *SCPServer) QueryByID(id int) *scp.Conn {
@@ -276,6 +281,7 @@ func NewSCPServer(options *Options) *SCPServer {
 	return &SCPServer{
 		options:      options,
 		reuseTimeout: time.Duration(options.reuseTimeout) * time.Second,
+		handshakeTimeout: time.Duration(options.handshakeTimeout) * time.Second,
 		idAllocator:  scp.NewIDAllocator(1),
 		connPairs:    make(map[int]*ConnPair),
 	}


### PR DESCRIPTION
目前只要连上 tcp，不进行握手操作，不会有任何超时剔除机制

Nginx 针对HTTP协议，有 client_header_timeout、client_body_timeout、send_timeout 三个参数，分别设置读取客户端请求头、读取客户端请求内容体、服务器返回resp的两次成功 write 操作时限。

参考 Nginx，新增了 handshakeTimeout 设定。handshakeTimeout 类似于 client_header_timeout + client_body_timeout +（Nginx 目前没有的写整个 resp 的时限设定）。超时后提示 handshake timeout