### PR TITLE
修复client访问未初始化ScpServer变量的bug

### DIFF
--- a/scp/conn.go
+++ b/scp/conn.go
@@ -421,18 +421,22 @@ func (c *Conn) handshake() error {
 }
 
 func (c *Conn) Handshake() error {
-	var err error
-	done := make(chan struct{})
-	go func() {
-		err = c.handshake()
-		close(done)
-	}()
-	handshake_timeout := c.config.ScpServer.HandshakeTimeout()
-	select {
-	case <-time.After(handshake_timeout):
-		return errors.New("handshake timeout")
-	case <-done:
-		return err
+	if c.config.ScpServer == nil {
+		return c.handshake()
+	} else {
+		var err error
+		done := make(chan struct{})
+		go func() {
+			err = c.handshake()
+			close(done)
+		}()
+		handshake_timeout := c.config.ScpServer.HandshakeTimeout()
+		select {
+		case <-time.After(handshake_timeout):
+			return errors.New("handshake timeout")
+		case <-done:
+			return err
+		}
 	}
 }
 

--- a/scp/conn.go
+++ b/scp/conn.go
@@ -430,9 +430,9 @@ func (c *Conn) Handshake() error {
 			err = c.handshake()
 			close(done)
 		}()
-		handshake_timeout := c.config.ScpServer.HandshakeTimeout()
+		handshakeTimeout := c.config.ScpServer.HandshakeTimeout()
 		select {
-		case <-time.After(handshake_timeout):
+		case <-time.After(handshakeTimeout):
 			return errors.New("handshake timeout")
 		case <-done:
 			return err


### PR DESCRIPTION
client调用Handshake时，会跑到Handshake超时判断逻辑，但是没有配超时
秒数，会导致client crash。现在对client关闭这段判断逻辑