### PR TITLE
bugfix: shouldn't save the addresses of loop variables

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,4 +26,4 @@ kcp_option:
 hosts:
   - name: test1
     addr: 127.0.0.1:11248
-    weigh: 100
+    weight: 100

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -61,7 +61,8 @@ func (u *upstreams) UpdateHosts(hosts []Host) error {
 	allHosts.weight = 0
 
 	byNameHosts := make(map[string]*hostGroup)
-	for _, h := range hosts {
+	for _, host := range hosts {
+		h := host
 		addr, err := net.ResolveTCPAddr("tcp", h.Addr)
 		if err != nil {
 			return err


### PR DESCRIPTION
重现方式：配置多个地址，最终goscon只会使用最后一个。