### PR TITLE
goscon as a proxy

### DIFF
--- a/config.go
+++ b/config.go
@@ -51,7 +51,7 @@ func init() {
 	viper.SetDefault("kcp_option.opt_stream", true)      // kcp opt_stream: true, 是否启用kcp流模式; 流模式下，会合并udp包发送
 	viper.SetDefault("kcp_option.opt_writedelay", false) // kcp opt_writedelay: false, 延迟到下次interval发送数据
 
-	viper.SetDefault("upstream_option.net", "tcp") // upstream net: tcp,  默认使用 tcp 连接后端服务器
+	viper.SetDefault("upstream_option.net", "tcp") // upstream net: tcp,  默认使用 tcp 连接后端服务器，可以指定使用 scp 协议保证连接自动重连。
 
 	configCache = make(map[string]interface{})
 }

--- a/config.yaml
+++ b/config.yaml
@@ -23,7 +23,12 @@ kcp_option:
   opt_sndwnd: 2048
   opt_rcvwnd: 2048
   opt_stream: true
+upstream_option:
+  net: tcp
 hosts:
   - name: test1
     addr: 127.0.0.1:11248
+    weight: 100
+  - name: test2
+    addr: 127.0.0.1:11249
     weight: 100

--- a/localconn.go
+++ b/localconn.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"net"
+	"sync"
+
+	"github.com/ejoy/goscon/scp"
+	"github.com/xjdrew/glog"
+)
+
+// LocalSCPConn .
+type LocalSCPConn struct {
+	*SCPConn
+}
+
+// ReuseConn reused conn, only valid for scp conn
+func reuseConn(connForReused *scp.Conn) (conn net.Conn, err error) {
+	addr, _ := net.ResolveTCPAddr("tcp", connForReused.RemoteAddr().String())
+	tcpConn, err := net.DialTCP("tcp", nil, addr)
+	if err != nil {
+		glog.Errorf("connect to <%s> failed: %s when reuse conn", addr.String(), err.Error())
+		return
+	}
+
+	scon, err := scp.Client(tcpConn, &scp.Config{
+		ConnForReused: connForReused,
+		TargetServer:  connForReused.TargetServer(),
+	})
+	if err != nil {
+		glog.Errorf("scp reuse conn failed: %s", err.Error())
+		return
+	}
+
+	err = scon.Handshake()
+	if err != nil {
+		glog.Errorf("scp reuse handshake failed: client=%s, err=%s", scon.RemoteAddr().String(), err.Error())
+		scon.Close()
+		return
+	}
+
+	conn = scon
+	return
+}
+
+func (c *LocalSCPConn) reuseConn() {
+	conn, err := reuseConn(c.Conn)
+	if err != nil {
+		return
+	}
+	scon := conn.(*scp.Conn)
+	if !c.ReplaceConn(scon) {
+		scon.Close()
+	}
+}
+
+// startWait 开启超时计数，发起重连操作
+func (c *LocalSCPConn) startWait() {
+	c.SCPConn.startWait()
+	go c.reuseConn() // reuse the upstream scp.conn
+}
+
+// NewLocalSCPConn .
+func NewLocalSCPConn(scon *scp.Conn) *LocalSCPConn {
+	scpConn := &SCPConn{Conn: scon}
+	scpConn.connCond = sync.NewCond(&scpConn.connMutex)
+	scpConn.reuseTimeout = configItemTime("scp.reuse_time")
+	localSCPConn := &LocalSCPConn{SCPConn: scpConn}
+	return localSCPConn
+}

--- a/localconn.go
+++ b/localconn.go
@@ -13,7 +13,7 @@ type LocalSCPConn struct {
 	*SCPConn
 }
 
-// ReuseConn reused conn, only valid for scp conn
+// ReuseConn reused conn
 func reuseConn(connForReused *scp.Conn) (conn net.Conn, err error) {
 	addr, _ := net.ResolveTCPAddr("tcp", connForReused.RemoteAddr().String())
 	tcpConn, err := net.DialTCP("tcp", nil, addr)
@@ -53,7 +53,7 @@ func (c *LocalSCPConn) reuseConn() {
 	}
 }
 
-// startWait 开启超时计数，发起重连操作
+// startWait start reuse timer and reuse conn
 func (c *LocalSCPConn) startWait() {
 	c.SCPConn.startWait()
 	go c.reuseConn() // reuse the upstream scp.conn

--- a/protocol.md
+++ b/protocol.md
@@ -14,16 +14,17 @@ Client->Server: 传输一个 2 byte size(big-endian) + content 的包, size == l
 0\n
 base64(DHPublicKey)\n
 targetServer\n
-flags
+flag
 ```
 
 `DHPublicKey` 是一个 8 bytes 值, 经过 DH 算法计算出来的 key。
 
 `targetServer`用于提示优先连接的后端服务器名字。`targetServer`应该仅包括[a-zA-Z_0-9]。
 
-`flags` 32 位标志位，用于标志发起方连接选项。
+`flag` 32 位整形，允许通过设置不同的比特位开启不同的选项。
 
-- 0x1 表示需要将 client ip 发送给服务节点。
+- 比特位 1: 表示禁止将 client ip 发送给 upstream。
+- ...
 
 ```
 DHPrivateKey = dh64.PrivateKey()

--- a/protocol.md
+++ b/protocol.md
@@ -13,12 +13,17 @@ Client->Server: 传输一个 2 byte size(big-endian) + content 的包, size == l
 ```
 0\n
 base64(DHPublicKey)\n
-targetServer
+targetServer\n
+flags
 ```
 
-DHPublicKey 是一个 8 bytes 值, 经过 DH 算法计算出来的 key。
+`DHPublicKey` 是一个 8 bytes 值, 经过 DH 算法计算出来的 key。
 
 `targetServer`用于提示优先连接的后端服务器名字。`targetServer`应该仅包括[a-zA-Z_0-9]。
+
+`flags` 32 位标志位，用于标志发起方连接选项。
+
+- 0x1 表示需要将 client ip 发送给服务节点。
 
 ```
 DHPrivateKey = dh64.PrivateKey()

--- a/scp/common.go
+++ b/scp/common.go
@@ -2,11 +2,17 @@ package scp
 
 import (
 	"fmt"
+	"time"
 )
 
-var NetBufferSize = 32 * 1024   // 32k
-var RueseBufferSize = 64 * 1024 // 64k
+// NetBufferSize .
+var NetBufferSize = 32 * 1024 // 32k
+// ReuseBufferSize .
+var ReuseBufferSize = 64 * 1024 // 64k
+// HandshakeTimeout .
+var HandshakeTimeout time.Duration // 0s
 
+// SCPStatus Code
 const (
 	SCPStatusOK            = 200 // succeed
 	SCPStatusBadRequest    = 400 // malformed request
@@ -28,10 +34,19 @@ func (se *Error) Error() string {
 	return fmt.Sprintf("%d %s", se.Code, se.Desc)
 }
 
+// ErrIllegalMsg .
 var ErrIllegalMsg = &Error{400, "illegal message"}
+
+// ErrUnauthorized .
 var ErrUnauthorized = &Error{401, "Unauthorized"}
+
+// ErrIndexExpired .
 var ErrIndexExpired = &Error{403, "Index Expired"}
+
+// ErrIDNotFound .
 var ErrIDNotFound = &Error{404, "ID Not Found"}
+
+// ErrNotAcceptable .
 var ErrNotAcceptable = &Error{406, "Not Acceptable"}
 
 func newError(code int) error {

--- a/scp/conn.go
+++ b/scp/conn.go
@@ -564,7 +564,7 @@ func (c *Conn) TargetServer() string {
 	return c.config.TargetServer
 }
 
-// ForwardIP .
-func (c *Conn) ForwardIP() bool {
-	return c.config.Flags&SCPFlagsForwardIP > 0
+// ForbidForwardIP .
+func (c *Conn) ForbidForwardIP() bool {
+	return c.config.Flag&SCPFlagForbidForwardIP > 0
 }

--- a/scp/loopbuffer.go
+++ b/scp/loopbuffer.go
@@ -103,9 +103,9 @@ func (p *loopBufferPool) Get() *loopBuffer {
 	return b
 }
 
-// if RueseBufferSize changes, invalidate all old buffer
+// if ReuseBufferSize changes, invalidate all old buffer
 func (p *loopBufferPool) Put(v *loopBuffer) {
-	if v.Cap() != RueseBufferSize {
+	if v.Cap() != ReuseBufferSize {
 		return
 	}
 	p.pool.Put(v)
@@ -115,7 +115,7 @@ func newLoopBufferPool() *loopBufferPool {
 	return &loopBufferPool{
 		pool: sync.Pool{
 			New: func() interface{} {
-				return newLoopBuffer(RueseBufferSize)
+				return newLoopBuffer(ReuseBufferSize)
 			},
 		},
 	}

--- a/scp/messages.go
+++ b/scp/messages.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 )
 
-// 32 bit flags definitions for SCPConn.
+// 32 bit flag definitions for SCPConn.
 const (
-	SCPFlagsForwardIP = 0x1
+	SCPFlagForbidForwardIP = 0x1
 	// ...
 )
 
@@ -43,12 +43,12 @@ type newConnReq struct {
 	id           int
 	key          leu64
 	targetServer string
-	// 32 bit flags for different extension, see SCPFlags
-	flags int
+	// 32 bit flag for different extension, see SCPFlag
+	flag int
 }
 
 func (r *newConnReq) marshal() []byte {
-	s := fmt.Sprintf("%d\n%s\n%s\n%d", r.id, b64encodeLeu64(r.key), r.targetServer, r.flags)
+	s := fmt.Sprintf("%d\n%s\n%s\n%d", r.id, b64encodeLeu64(r.key), r.targetServer, r.flag)
 	return []byte(s)
 }
 
@@ -72,7 +72,7 @@ func (r *newConnReq) unmarshal(s []byte) (err error) {
 	}
 
 	if len(lines) >= 4 {
-		if r.flags, err = strconv.Atoi(lines[3]); err != nil {
+		if r.flag, err = strconv.Atoi(lines[3]); err != nil {
 			return
 		}
 	}

--- a/scp/messages.go
+++ b/scp/messages.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 )
 
+// 32 bit flags definitions for SCPConn.
+const (
+	SCPFlagsForwardIP = 0x1
+	// ...
+)
+
 func b64decodeLeu64(src string) (v leu64, err error) {
 	n := base64.StdEncoding.DecodedLen(len(src))
 	if n < 8 {
@@ -37,13 +43,12 @@ type newConnReq struct {
 	id           int
 	key          leu64
 	targetServer string
+	// 32 bit flags for different extension, see SCPFlags
+	flags int
 }
 
 func (r *newConnReq) marshal() []byte {
-	s := fmt.Sprintf("%d\n%s", r.id, b64encodeLeu64(r.key))
-	if r.targetServer != "" {
-		s += fmt.Sprintf("\n%s", r.targetServer)
-	}
+	s := fmt.Sprintf("%d\n%s\n%s\n%d", r.id, b64encodeLeu64(r.key), r.targetServer, r.flags)
 	return []byte(s)
 }
 
@@ -64,6 +69,12 @@ func (r *newConnReq) unmarshal(s []byte) (err error) {
 
 	if len(lines) >= 3 {
 		r.targetServer = lines[2]
+	}
+
+	if len(lines) >= 4 {
+		if r.flags, err = strconv.Atoi(lines[3]); err != nil {
+			return
+		}
 	}
 	return
 }

--- a/scp/scp.go
+++ b/scp/scp.go
@@ -28,6 +28,10 @@ type Config struct {
 	// SCPServer
 	// for server
 	ScpServer SCPServer
+
+	// Flags
+	// for server
+	Flags int
 }
 
 var defaultConfig = &Config{}

--- a/scp/scp.go
+++ b/scp/scp.go
@@ -29,9 +29,9 @@ type Config struct {
 	// for server
 	ScpServer SCPServer
 
-	// Flags
+	// Flag
 	// for server
-	Flags int
+	Flag int
 }
 
 var defaultConfig = &Config{}

--- a/scp/scp.go
+++ b/scp/scp.go
@@ -17,6 +17,10 @@ type SCPServer interface {
 }
 
 type Config struct {
+	// Flag
+	// for client
+	Flag int
+
 	// preferred target server
 	// for client
 	TargetServer string
@@ -28,10 +32,6 @@ type Config struct {
 	// SCPServer
 	// for server
 	ScpServer SCPServer
-
-	// Flag
-	// for server
-	Flag int
 }
 
 var defaultConfig = &Config{}

--- a/scpconn.go
+++ b/scpconn.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ejoy/goscon/scp"
+	"github.com/ejoy/goscon/upstream"
 )
 
 var errConnClosed = errors.New("conn closed")
@@ -41,6 +42,17 @@ func (s *SCPConn) setConnError(conn *scp.Conn, err error) {
 	s.connErr = err
 }
 
+func (s *SCPConn) reuseConn() {
+	conn, err := upstream.ReuseConn(s.Conn)
+	if err != nil {
+		return
+	}
+	scon := conn.(*scp.Conn)
+	if !s.ReplaceConn(scon) {
+		scon.Close()
+	}
+}
+
 // startWait 启动超时计数
 func (s *SCPConn) startWait() {
 	if s.reuseCh != nil {
@@ -56,6 +68,9 @@ func (s *SCPConn) startWait() {
 		}
 	}()
 	s.reuseCh = done
+	if !s.IsServerConn() { // reuse the upstream scp.conn
+		go s.reuseConn()
+	}
 }
 
 // stopWait 停止超时计数
@@ -83,6 +98,11 @@ func (s *SCPConn) acquireConn() (*scp.Conn, error) {
 	}
 }
 
+// Freeze will suspend the scon until connection closed or new connection established.
+func (s *SCPConn) Freeze(conn *scp.Conn) {
+	conn.Freeze()
+}
+
 // Read .
 func (s *SCPConn) Read(p []byte) (int, error) {
 	conn, err := s.acquireConn()
@@ -93,7 +113,7 @@ func (s *SCPConn) Read(p []byte) (int, error) {
 	n, err := conn.Read(p)
 	if err != nil {
 		// freeze, waiting for reuse
-		conn.Freeze()
+		s.Freeze(conn)
 		s.setConnError(conn, err)
 	}
 	return n, nil
@@ -111,7 +131,7 @@ func (s *SCPConn) Write(p []byte) (int, error) {
 
 		if err != nil {
 			// freeze, waiting for reuse
-			conn.Freeze()
+			s.Freeze(conn)
 			s.setConnError(conn, err)
 		}
 		nn = nn + n

--- a/server.go
+++ b/server.go
@@ -172,7 +172,7 @@ func newUpstreamConn(scon *scp.Conn) (conn net.Conn, err error) {
 		return
 	}
 	if scon, ok := localconn.(*scp.Conn); ok {
-		conn = NewSCPConn(scon)
+		conn = NewLocalSCPConn(scon)
 	} else {
 		conn = localconn
 	}

--- a/upstream/hooks.go
+++ b/upstream/hooks.go
@@ -2,11 +2,14 @@ package upstream
 
 import (
 	"net"
+
+	"github.com/ejoy/goscon/scp"
 )
 
 // Hook defines hook interface for upstream
 type Hook interface {
-	AfterConnected(local net.Conn, remote net.Conn) (err error)
+	IfEnable(local net.Conn, remote *scp.Conn) bool
+	AfterConnected(local net.Conn, remote *scp.Conn) (err error)
 }
 
 // installed hook
@@ -19,8 +22,16 @@ func setHook(hook Hook) {
 	upstreamHook = hook
 }
 
+// IfEnable check upstream hook whether enabled for the connection pair
+func IfEnable(local net.Conn, remote *scp.Conn) bool {
+	if upstreamHook == nil {
+		return true
+	}
+	return upstreamHook.IfEnable(local, remote)
+}
+
 // OnAfterConnected call when upstream connection is connected
-func OnAfterConnected(local net.Conn, remote net.Conn) (err error) {
+func OnAfterConnected(local net.Conn, remote *scp.Conn) (err error) {
 	if upstreamHook == nil {
 		return
 	}

--- a/upstream/hooks.go
+++ b/upstream/hooks.go
@@ -8,7 +8,6 @@ import (
 
 // Hook defines hook interface for upstream
 type Hook interface {
-	IfEnable(local net.Conn, remote *scp.Conn) bool
 	AfterConnected(local net.Conn, remote *scp.Conn) (err error)
 }
 
@@ -20,14 +19,6 @@ func setHook(hook Hook) {
 		panic("setHook again")
 	}
 	upstreamHook = hook
-}
-
-// IfEnable check upstream hook whether enabled for the connection pair
-func IfEnable(local net.Conn, remote *scp.Conn) bool {
-	if upstreamHook == nil {
-		return true
-	}
-	return upstreamHook.IfEnable(local, remote)
 }
 
 // OnAfterConnected call when upstream connection is connected

--- a/upstream/sproto_hook.go
+++ b/upstream/sproto_hook.go
@@ -5,10 +5,10 @@ package upstream
 import (
 	"bytes"
 	"encoding/binary"
-	"flag"
 	"net"
 	"sync"
 
+	"github.com/ejoy/goscon/scp"
 	sproto "github.com/xjdrew/gosproto"
 )
 
@@ -49,15 +49,11 @@ func (s *sprotoHook) init() {
 	s.packHeader = sproto.MustEncode(pack)
 }
 
-func (s *sprotoHook) AfterConnected(local net.Conn, remote net.Conn) (err error) {
-	if !flag.Parsed() {
-		return
-	}
+func (s *sprotoHook) IfEnable(local net.Conn, remote *scp.Conn) bool {
+	return remote.ForwardIP()
+}
 
-	if optSproto == -1 {
-		return
-	}
-
+func (s *sprotoHook) AfterConnected(local net.Conn, remote *scp.Conn) (err error) {
 	if s.packHeader == nil {
 		s.init()
 	}
@@ -80,7 +76,5 @@ func (s *sprotoHook) AfterConnected(local net.Conn, remote net.Conn) (err error)
 }
 
 func init() {
-	flag.IntVar(&optSproto, "sproto", -1, "sproto message type")
-
 	setHook(&sprotoHook{})
 }

--- a/upstream/sproto_hook.go
+++ b/upstream/sproto_hook.go
@@ -52,11 +52,11 @@ func (s *sprotoHook) init() {
 
 func (s *sprotoHook) AfterConnected(local net.Conn, remote *scp.Conn) (err error) {
 	if !flag.Parsed() {
-		return	}
+		return
 	}
 
 	if optSproto == -1 {
-		return	
+		return
 	}
 
 	if remote.ForbidForwardIP() {

--- a/upstream/sproto_hook.go
+++ b/upstream/sproto_hook.go
@@ -5,6 +5,7 @@ package upstream
 import (
 	"bytes"
 	"encoding/binary"
+	"flag"
 	"net"
 	"sync"
 
@@ -49,11 +50,19 @@ func (s *sprotoHook) init() {
 	s.packHeader = sproto.MustEncode(pack)
 }
 
-func (s *sprotoHook) IfEnable(local net.Conn, remote *scp.Conn) bool {
-	return remote.ForwardIP()
-}
-
 func (s *sprotoHook) AfterConnected(local net.Conn, remote *scp.Conn) (err error) {
+	if !flag.Parsed() {
+		return	}
+	}
+
+	if optSproto == -1 {
+		return	
+	}
+
+	if remote.ForbidForwardIP() {
+		return
+	}
+
 	if s.packHeader == nil {
 		s.init()
 	}
@@ -76,5 +85,7 @@ func (s *sprotoHook) AfterConnected(local net.Conn, remote *scp.Conn) (err error
 }
 
 func init() {
+	flag.IntVar(&optSproto, "sproto", -1, "sproto message type")
+
 	setHook(&sprotoHook{})
 }

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -154,7 +154,6 @@ func upgradeNetConn(network string, localConn net.Conn, remoteConn *scp.Conn) (c
 		err = scon.Handshake()
 		if err != nil {
 			glog.Errorf("scp handshake failed: client=%s, err=%s", scon.RemoteAddr().String(), err.Error())
-			scon.Close()
 			return
 		}
 		conn = scon
@@ -183,6 +182,7 @@ func (u *upstreams) NewConn(remoteConn *scp.Conn) (conn net.Conn, err error) {
 
 	conn, err = upgradeNetConn(u.option.Net, tcpConn, remoteConn)
 	if err != nil {
+		conn.Close()
 		return
 	}
 

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -13,9 +13,6 @@ import (
 // ErrNoHost .
 var ErrNoHost = errors.New("no host")
 
-// ErrInvalidOption .
-var ErrInvalidOption = errors.New("invalid option")
-
 const defaultWeight = 100
 
 // Option decribes upstream option

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -147,7 +147,7 @@ func (u *upstreams) GetHost(preferred string) *Host {
 	return u.GetHostByWeight()
 }
 
-func upgradeNetConn(network string, localConn net.Conn, remoteConn *scp.Conn) (conn net.Conn, err error) {
+func upgradeConn(network string, localConn net.Conn, remoteConn *scp.Conn) (conn net.Conn, err error) {
 	if network == "scp" {
 		scon, _ := scp.Client(localConn, &scp.Config{TargetServer: remoteConn.TargetServer()})
 
@@ -180,7 +180,7 @@ func (u *upstreams) NewConn(remoteConn *scp.Conn) (conn net.Conn, err error) {
 		return
 	}
 
-	conn, err = upgradeNetConn(u.option.Net, tcpConn, remoteConn)
+	conn, err = upgradeConn(u.option.Net, tcpConn, remoteConn)
 	if err != nil {
 		conn.Close()
 		return


### PR DESCRIPTION
1. 握手协议支持 32 位 flags 字段，指示不同的客户端连接请求。目前支持 forwardip 选项（0x1标记位）
2. goscon 支持 upstream 连接为 scpconn 连接，且处理断开重连逻辑。