### PR TITLE
support multiple listen server

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,26 +4,57 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 	"sync"
-	"time"
 
-	"github.com/ejoy/goscon/scp"
 	"github.com/ejoy/goscon/upstream"
 	"github.com/spf13/viper"
 	"github.com/xjdrew/glog"
 	yaml "gopkg.in/yaml.v2"
 )
 
-var (
-	configMu    sync.Mutex
-	configCache map[string]interface{}
-)
-
 // ErrInvalidConfig .
 var ErrInvalidConfig = errors.New("Invalid Config")
 
-// init default configure
+// ErrTCPOrKCP .
+var ErrTCPOrKCP = errors.New("Need tcp or kcp listen")
+
+// ErrNoHostOrResolv .
+var ErrNoHostOrResolv = errors.New("No hosts or resolv rule configed")
+
+// ViperConfigSchema .
+type ViperConfigSchema struct {
+	Manager        string             `mapstructure:"manager"`
+	SCPOption      *SCPOption         `mapstructure:"scp_option"`
+	TCPOption      *TCPOption         `mapstructure:"tcp_option"`
+	KCPOption      *KCPOption         `mapstructure:"kcp_option"`
+	UpstreamOption *upstream.Option   `mapstructure:"upstream_option"`
+	Server         map[string]*Option `mapstructure:"server"`
+}
+
+// ViperConfig .
+type ViperConfig struct {
+	mu sync.Mutex
+
+	current    *viper.Viper
+	configFile string
+}
+
+var (
+	viperConfig *ViperConfig
+)
+
 func init() {
+	viperConfig = &ViperConfig{}
+}
+
+// setConfigFile .
+func (v *ViperConfig) setConfigFile(file string) {
+	v.configFile = file
+}
+
+// set default configure
+func (v *ViperConfig) setDefault(viper *viper.Viper) {
 	viper.SetDefault("manager", "127.0.0.1:6620") // manager: listen address, 为空表示不启用管理功能
 
 	viper.SetDefault("tcp", "0.0.0.0:1248") // listen tcp: yes
@@ -56,11 +87,9 @@ func init() {
 	viper.SetDefault("kcp_option.opt_writedelay", false) // kcp opt_writedelay: false, 延迟到下次interval发送数据
 
 	viper.SetDefault("upstream_option.net", "tcp") // upstream net: tcp,  默认使用 tcp 连接后端服务器，可以指定使用 scp 协议保证连接自动重连。
-
-	configCache = make(map[string]interface{})
 }
 
-func marshalConfigFile() (s string) {
+func (v *ViperConfig) marshalConfigFile(viper *viper.Viper) (s string) {
 	c := viper.AllSettings()
 	b, err := yaml.Marshal(c)
 	if err != nil {
@@ -75,100 +104,191 @@ func marshalConfigFile() (s string) {
 	return
 }
 
-func reloadConfig() (err error) {
-	glog.Info("load config")
+func checkUpstreamOption(viper *viper.Viper, key string) error {
+	var upstreamOption upstream.Option
+	viper.UnmarshalKey(key, &upstreamOption)
+	if upstreamOption.Resolv != nil {
+		if err := upstreamOption.Resolv.Normalize(); err != nil {
+			glog.Errorf("invalid pattern for validates the domain name: %s", err.Error())
+			return err
+		}
+	}
+	return nil
+}
+
+func checkDefaultOption(viper *viper.Viper) error {
+	if err := checkUpstreamOption(viper, "upstream_option"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkServerOption(viper *viper.Viper, serverType string) error {
+	if !(viper.IsSet(serverType+".tcp") || viper.IsSet(serverType+".kcp")) {
+		return ErrTCPOrKCP
+	}
+	if err := checkUpstreamOption(viper, serverType+".upstream_option"); err != nil {
+		return err
+	}
+	if !(viper.IsSet(serverType+".upstream_option.resolv") || viper.IsSet(serverType+".upstream_option.hosts")) {
+		return ErrNoHostOrResolv
+	}
+	return nil
+}
+
+// reloadConfig .
+func (v *ViperConfig) reloadConfig() (err error) {
+	glog.Info("reload config")
 
 	// try to load config from disk
-	if viper.ConfigFileUsed() == "" {
+	if v.configFile == "" {
 		if glog.V(3) {
 			glog.Error("no config file used")
 		}
 		return ErrInvalidConfig
 	}
 
-	if err = viper.ReadInConfig(); err != nil {
+	newViper := viper.New()
+	newViper.SetConfigFile(v.configFile)
+
+	if err = newViper.ReadInConfig(); err != nil {
 		glog.Errorf("read configuration failed: %s", err.Error())
 		return ErrInvalidConfig
 	}
 
-	// print current config
-	glog.Info(marshalConfigFile())
-
-	// clear cache
-	configMu.Lock()
-	for k := range configCache {
-		delete(configCache, k)
+	// print the new config
+	if configString := v.marshalConfigFile(newViper); configString != "" {
+		glog.Info(configString)
+	} else {
+		return ErrInvalidConfig
 	}
-	configMu.Unlock()
 
-	var option upstream.Option
-	if err = viper.UnmarshalKey("upstream_option", &option); err != nil {
-		glog.Errorf("unmarshal option failed: %s", err.Error())
+	var config ViperConfigSchema
+	if err := newViper.Unmarshal(&config); err != nil {
+		glog.Errorf("Config file is invalid: %s", err.Error())
 		return err
 	}
 
-	if option.Resolv != nil {
-		if err := option.Resolv.Normalize(); err != nil {
-			glog.Errorf("invalid pattern for validates the domain name: %s", err.Error())
-			return ErrInvalidConfig
+	if err := checkDefaultOption(newViper); err != nil {
+		glog.Errorf("check default option failed: %s", err.Error())
+		return err
+	}
+
+	server := newViper.GetStringMap("server")
+	for typ := range server {
+		if err := checkServerOption(newViper, "server."+typ); err != nil {
+			glog.Errorf("check server:%s option failed: %s", typ, err.Error())
+			return err
 		}
 	}
 
-	// update upstream
-	var hosts []upstream.Host
-	if err = viper.UnmarshalKey("hosts", &hosts); err != nil {
-		glog.Errorf("unmarshal hosts failed: %s", err.Error())
-		return err
-	}
+	v.setDefault(newViper)
 
-	if err = upstream.UpdateHosts(&option, hosts); err != nil {
-		glog.Errorf("upstream update hosts failed: %s", err.Error())
-		return err
-	}
+	v.mu.Lock()
+	v.current = newViper
+	v.mu.Unlock()
 
-	// Truly update all the config state, should not error below.
-
-	// set upstream option
-	upstream.SetOption(&option)
-
-	// update scp
-	reuseBuffer := viper.GetInt("scp.reuse_buffer")
-	if reuseBuffer > 0 {
-		scp.ReuseBufferSize = reuseBuffer
-	}
-	handshakeTimeout := viper.GetInt("scp.handshake_timeout")
-	if handshakeTimeout > 0 {
-		scp.HandshakeTimeout = time.Duration(handshakeTimeout) * time.Second
-	}
 	return
 }
 
-func configItemBool(name string) bool {
-	configMu.Lock()
-	defer configMu.Unlock()
-	if v, ok := configCache[name]; ok {
-		return v.(bool)
+// getServers .
+func (v *ViperConfig) getServers() []string {
+	var tempViper *viper.Viper
+	v.mu.Lock()
+	tempViper = v.current
+	v.mu.Unlock()
+	servers := tempViper.GetStringMap("server")
+	serverList := make([]string, 0, len(servers))
+	for s := range servers {
+		serverList = append(serverList, s)
 	}
-	v := viper.GetBool(name)
-	configCache[name] = v
-	return v
+	return serverList
 }
 
-func configItemInt(name string) int {
-	configMu.Lock()
-	defer configMu.Unlock()
-	if v, ok := configCache[name]; ok {
-		return v.(int)
+func setDefaultField(viper *viper.Viper, m map[string]interface{}, root string, fields ...string) {
+	dotField := strings.Join(fields, ".")
+	if !viper.IsSet(root + "." + dotField) {
+		leaf := m
+		lastIndex := len(fields) - 1
+		for i := 0; i != lastIndex; i++ {
+			leaf = leaf[fields[i]].(map[string]interface{})
+		}
+		leaf[fields[lastIndex]] = viper.Get(dotField)
 	}
-	v := viper.GetInt(name)
-	configCache[name] = v
-	return v
 }
 
-func configItemTime(name string) time.Duration {
-	seconds := configItemInt(name)
-	if seconds <= 0 {
-		return 0
+// getServerOption .
+func (v *ViperConfig) getServerOption(typ string) *Option {
+	var tempViper *viper.Viper
+	v.mu.Lock()
+	tempViper = v.current
+	v.mu.Unlock()
+
+	serverType := "server." + typ
+	if !tempViper.IsSet(serverType) {
+		return nil
 	}
-	return time.Duration(seconds) * time.Second
+	optionMap := tempViper.GetStringMap(serverType)
+	// tcp option
+	if tempViper.IsSet(serverType + ".tcp") {
+		setDefaultField(tempViper, optionMap, serverType, "tcp_option")
+		setDefaultField(tempViper, optionMap, serverType, "tcp_option", "read_timeout")
+		setDefaultField(tempViper, optionMap, serverType, "tcp_option", "keepalive")
+		setDefaultField(tempViper, optionMap, serverType, "tcp_option", "keepalive_interval")
+	}
+	// kcp option
+	if tempViper.IsSet(serverType + ".kcp") {
+		setDefaultField(tempViper, optionMap, serverType, "kcp_option")
+		for field := range tempViper.GetStringMap("kcp_option") {
+			setDefaultField(tempViper, optionMap, serverType, "kcp_option", field)
+		}
+	}
+	// scp option
+	setDefaultField(tempViper, optionMap, serverType, "scp_option")
+	setDefaultField(tempViper, optionMap, serverType, "scp_option", "handshake_timeout")
+	setDefaultField(tempViper, optionMap, serverType, "scp_option", "reuse_time")
+	setDefaultField(tempViper, optionMap, serverType, "scp_option", "reuse_buffer")
+	// upstream option
+	setDefaultField(tempViper, optionMap, serverType, "upstream_option")
+	setDefaultField(tempViper, optionMap, serverType, "upstream_option", "net")
+
+	var option Option
+	tempViper.UnmarshalKey(serverType, &option)
+	return &option
+}
+
+func (v *ViperConfig) get(key string) interface{} {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.current.Get(key)
+}
+
+// GetConfigManager .
+func GetConfigManager() string {
+	return viperConfig.get("manager").(string)
+}
+
+// SetConfigFile .
+func SetConfigFile(file string) {
+	viperConfig.setConfigFile(file)
+}
+
+// MarshalConfigFile .
+func MarshalConfigFile() string {
+	return viperConfig.marshalConfigFile(viperConfig.current)
+}
+
+// ReloadConfig .
+func ReloadConfig() error {
+	return viperConfig.reloadConfig()
+}
+
+// GetConfigServers .
+func GetConfigServers() []string {
+	return viperConfig.getServers()
+}
+
+// GetConfigServerOption .
+func GetConfigServerOption(typ string) *Option {
+	return viperConfig.getServerOption(typ)
 }

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,6 @@
 manager: 127.0.0.1:6620
-tcp: 0.0.0.0:1248
-kcp: 0.0.0.0:1248
-scp:
+## default options
+scp_option:
   handshake_timeout: 30
   reuse_time: 30
   reuse_buffer: 65536
@@ -25,15 +24,29 @@ kcp_option:
   opt_stream: true
 upstream_option:
   net: tcp
-#  resolv:
-#    port: 443
-#    suffix: .com
-#    prefix: mail.
-#    pattern : google
-hosts:
-  - name: test1
-    addr: 127.0.0.1:11248
-    weight: 100
-  - name: test2
-    addr: 127.0.0.1:11249
-    weight: 100
+## servers
+server:
+  gameserver:
+    tcp: 0.0.0.0:1248
+    kcp: 0.0.0.0:1248
+    scp_option:
+      reuse_buffer: 32768
+    upstream_option:
+      net: tcp
+      resolv:
+        port: 443
+        suffix: .com
+        prefix: mail.
+        pattern: google
+  whatever:
+    tcp: 0.0.0.0:1249
+    scp_option:
+      reuse_buffer: 65536
+    upstream_option:
+      hosts:
+        - name: test1
+          addr: 127.0.0.1:11248
+          weight: 100
+        - name: test2
+          addr: 127.0.0.1:11249
+          weight: 100

--- a/config.yaml
+++ b/config.yaml
@@ -32,24 +32,21 @@ resolv:
   suffix: .com
   prefix: mail.
   pattern: google
-upstream_option:
+upstream:
   net: tcp
 ## servers
 server:
-  gameserver:
-    tcp: 0.0.0.0:1248
-    kcp: 0.0.0.0:1248
+  default:
+    listen: 0.0.0.0:1248
+  custom:
+    listen: 0.0.0.0:1249
+    net: "tcp"
     scp_option:
-      reuse_buffer: 32768
-    upstream_option:
-      net: tcp
-      resolv: true
-  whatever:
-    tcp: 0.0.0.0:1249
-    scp_option:
+      reuse_time: 300
       reuse_buffer: 65536
-    upstream_option:
+    upstream:
       locations:
         - name: test1
           weight: 20
         - name: test2
+          weight: 30

--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,16 @@ kcp_option:
   opt_sndwnd: 2048
   opt_rcvwnd: 2048
   opt_stream: true
+hosts:
+  - name: test1
+    addr: 127.0.0.1:11248
+  - name: test2
+    addr: 127.0.0.1:11249
+resolv:
+  port: 443
+  suffix: .com
+  prefix: mail.
+  pattern: google
 upstream_option:
   net: tcp
 ## servers
@@ -33,20 +43,13 @@ server:
       reuse_buffer: 32768
     upstream_option:
       net: tcp
-      resolv:
-        port: 443
-        suffix: .com
-        prefix: mail.
-        pattern: google
+      resolv: true
   whatever:
     tcp: 0.0.0.0:1249
     scp_option:
       reuse_buffer: 65536
     upstream_option:
-      hosts:
+      locations:
         - name: test1
-          addr: 127.0.0.1:11248
-          weight: 100
+          weight: 20
         - name: test2
-          addr: 127.0.0.1:11249
-          weight: 100

--- a/localconn.go
+++ b/localconn.go
@@ -57,8 +57,8 @@ func (c *LocalSCPConn) startWait() {
 }
 
 // NewLocalSCPConn .
-func NewLocalSCPConn(scon *scp.Conn) *LocalSCPConn {
-	scpConn := NewSCPConn(scon)
+func NewLocalSCPConn(scon *scp.Conn, option *SCPOption) *LocalSCPConn {
+	scpConn := NewSCPConn(scon, option)
 	localSCPConn := &LocalSCPConn{SCPConn: scpConn}
 	return localSCPConn
 }

--- a/manager.go
+++ b/manager.go
@@ -24,11 +24,12 @@ func startManager(laddr string) (err error) {
 
 	http.HandleFunc("/config", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Add("Content-Type", "text/vnd.yaml")
-		io.WriteString(w, marshalConfigFile())
+		io.WriteString(w, MarshalConfigFile())
 	})
 
 	http.HandleFunc("/reload", func(w http.ResponseWriter, _ *http.Request) {
-		err := reloadConfig()
+		err := ReloadConfig()
+		reloadAllServers()
 		if err == nil {
 			io.WriteString(w, "succeed")
 		} else {

--- a/remoteconn.go
+++ b/remoteconn.go
@@ -158,9 +158,9 @@ func (s *SCPConn) Close() error {
 }
 
 // NewSCPConn .
-func NewSCPConn(scon *scp.Conn) *SCPConn {
+func NewSCPConn(scon *scp.Conn, option *SCPOption) *SCPConn {
 	scpConn := &SCPConn{Conn: scon}
 	scpConn.connCond = sync.NewCond(&scpConn.connMutex)
-	scpConn.reuseTimeout = configItemTime("scp.reuse_time")
+	scpConn.reuseTimeout = option.ReuseTime * time.Second
 	return scpConn
 }

--- a/scp/common.go
+++ b/scp/common.go
@@ -2,15 +2,12 @@ package scp
 
 import (
 	"fmt"
-	"time"
 )
 
 // NetBufferSize .
 var NetBufferSize = 32 * 1024 // 32k
 // ReuseBufferSize .
 var ReuseBufferSize = 64 * 1024 // 64k
-// HandshakeTimeout .
-var HandshakeTimeout time.Duration // 0s
 
 // SCPStatus Code
 const (

--- a/scp/conn.go
+++ b/scp/conn.go
@@ -147,7 +147,7 @@ type Conn struct {
 	handshakes int
 	secret     leu64
 
-	reuseBuffer *loopBuffer
+	reuseBuffer *LoopBuffer
 
 	reused bool // reused conn
 	resend int  // resend data length
@@ -156,7 +156,7 @@ type Conn struct {
 func (c *Conn) initNewConn(id int, secret leu64) {
 	c.id = id
 	c.secret = secret
-	c.reuseBuffer = getLoopBuffer(c.config.ReuseBufferSize)
+	c.reuseBuffer = c.getReuseBuffer()
 
 	c.in = newCipherConnReader(c.secret)
 	c.out = newCipherConnWriter(c.secret)
@@ -187,8 +187,11 @@ func (c *Conn) spawn(new *Conn) bool {
 	new.id = c.id
 	new.secret = c.secret
 
-	reuseBuffer := getLoopBuffer(c.config.ReuseBufferSize)
+	reuseBuffer := c.getReuseBuffer()
 	c.reuseBuffer.CopyTo(reuseBuffer)
+	// Keeps ReuseBuffer consistent with the old conn (reuse conn).
+	new.config.ReuseBufferSize = c.config.ReuseBufferSize
+	new.config.ReuseBufferPool = c.config.ReuseBufferPool
 	new.reuseBuffer = reuseBuffer
 	new.in = deepCopyCipherConnReader(c.in)
 	new.out = deepCopyCipherConnWriter(c.out)
@@ -197,6 +200,20 @@ func (c *Conn) spawn(new *Conn) bool {
 
 	new.reused = true
 	return true
+}
+
+func (c *Conn) getReuseBuffer() *LoopBuffer {
+	if c.config.ReuseBufferPool != nil {
+		return c.config.ReuseBufferPool.Get()
+	} else {
+		return NewLoopBuffer(c.config.ReuseBufferSize)
+	}
+}
+
+func (c *Conn) putReuseBuffer(v *LoopBuffer) {
+	if c.config.ReuseBufferPool != nil {
+		c.config.ReuseBufferPool.Put(v)
+	}
 }
 
 func (c *Conn) writeRecord(msg handshakeMessage) error {
@@ -536,7 +553,7 @@ func (c *Conn) Close() error {
 	c.freeze()
 
 	if c.reuseBuffer != nil {
-		putLoopBuffer(c.config.ReuseBufferSize, c.reuseBuffer)
+		c.putReuseBuffer(c.reuseBuffer)
 		c.reuseBuffer = nil
 	}
 	return nil
@@ -575,4 +592,9 @@ func (c *Conn) ForbidForwardIP() bool {
 // ReuseBufferSize .
 func (c *Conn) ReuseBufferSize() int {
 	return c.config.ReuseBufferSize
+}
+
+// ReuseBufferPool .
+func (c *Conn) ReuseBufferPool() *LoopBufferPool {
+	return c.config.ReuseBufferPool
 }

--- a/scp/loopbuffer.go
+++ b/scp/loopbuffer.go
@@ -97,6 +97,7 @@ func NewLoopBuffer(cap int) *LoopBuffer {
 
 // LoopBufferPool .
 type LoopBufferPool struct {
+	Cap  int
 	Pool sync.Pool
 }
 

--- a/scp/scp.go
+++ b/scp/scp.go
@@ -39,6 +39,11 @@ type Config struct {
 	// for server and client
 	ReuseBufferSize int
 
+	// ReuseBufferPool
+	// for optimize gc
+	// for server and client
+	ReuseBufferPool *LoopBufferPool
+
 	// HandshakeTimeout
 	HandshakeTimeout time.Duration
 }
@@ -49,6 +54,7 @@ func (config *Config) clone() *Config {
 	return &Config{
 		ScpServer:        config.ScpServer,
 		ReuseBufferSize:  config.ReuseBufferSize,
+		ReuseBufferPool:  config.ReuseBufferPool,
 		HandshakeTimeout: config.HandshakeTimeout,
 	}
 }

--- a/server.go
+++ b/server.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ejoy/goscon/scp"
@@ -64,35 +66,43 @@ func pump(id int, tag string, dst net.Conn, src net.Conn, ch chan<- int) error {
 	return err
 }
 
-func (p *connPair) Pump() {
-	glog.Infof("pair new: id=%d, client=%s->%s, server=%s->%s", p.RemoteConn.ID(), p.RemoteConn.RemoteAddr(),
+func (p *connPair) Pump(serverType string) {
+	glog.Infof("scpserver=%s pair new: id=%d, client=%s->%s, server=%s->%s", serverType, p.RemoteConn.ID(), p.RemoteConn.RemoteAddr(),
 		p.RemoteConn.LocalAddr(), p.LocalConn.LocalAddr(), p.LocalConn.RemoteAddr())
 	downloadCh := make(chan int)
 	uploadCh := make(chan int)
 
-	go pump(p.RemoteConn.ID(), "c2s", p.LocalConn, p.RemoteConn, downloadCh)
-	go pump(p.RemoteConn.ID(), "s2c", p.RemoteConn, p.LocalConn, uploadCh)
+	go pump(p.RemoteConn.ID(), serverType+":c2s", p.LocalConn, p.RemoteConn, downloadCh)
+	go pump(p.RemoteConn.ID(), serverType+":s2c", p.RemoteConn, p.LocalConn, uploadCh)
 
 	dlData := <-downloadCh
 	dlPackets := <-downloadCh
 	ulData := <-uploadCh
 	ulPackets := <-uploadCh
-	glog.Infof("pair remove: id=%d, client=%s, server=%s, c2s=%d/%d, s2c=%d/%d", p.RemoteConn.ID(),
+	glog.Infof("scpserver=%s pair remove: id=%d, client=%s, server=%s, c2s=%d/%d, s2c=%d/%d", serverType, p.RemoteConn.ID(),
 		p.RemoteConn.RemoteAddr(), p.LocalConn.LocalAddr(), dlData, dlPackets, ulData, ulPackets)
 }
 
 // SCPServer implements scp.SCPServer
 type SCPServer struct {
+	typ    string // server type
+	option atomic.Value
+	wg     sync.WaitGroup
+
 	idAllocator *scp.IDAllocator
+
+	// listener -> scp server -> upstreams
+	// support tcp/kcp listener
+
+	tcpListener  *TCPListener
+	kcpListeners []*KCPListener // reuseport
+	upstreams    *upstream.Upstreams
 
 	connPairMutex sync.Mutex
 	connPairs     map[int]*connPair
 }
 
-var defaultServer = &SCPServer{
-	idAllocator: scp.NewIDAllocator(1),
-	connPairs:   make(map[int]*connPair),
-}
+var allServers = make(map[string]*SCPServer)
 
 // AcquireID implments scp.SCPServer interface
 func (ss *SCPServer) AcquireID() int {
@@ -119,7 +129,7 @@ func (ss *SCPServer) addConnPair(id int, pair *connPair) {
 	ss.connPairMutex.Lock()
 	defer ss.connPairMutex.Unlock()
 	if _, ok := ss.connPairs[id]; ok {
-		glog.Errorf("pair id conflict: id=%d", id)
+		glog.Errorf("pair id conflict: server=%s, id=%d", ss.typ, id)
 		panic(id)
 	}
 	ss.connPairs[id] = pair
@@ -147,7 +157,7 @@ func (ss *SCPServer) onReuseConn(scon *scp.Conn) bool {
 		scon.Close()
 		connectionReuseFails.Inc()
 
-		glog.Errorf("pair reuse failed: id=%d, new_client=%s, err=no pair", id, scon.RemoteAddr())
+		glog.Errorf("server=%s pair reuse failed: id=%d, new_client=%s, err=no pair", ss.typ, id, scon.RemoteAddr())
 		return false
 	}
 
@@ -156,23 +166,24 @@ func (ss *SCPServer) onReuseConn(scon *scp.Conn) bool {
 		scon.Close()
 		connectionReuseFails.Inc()
 
-		glog.Errorf("pair reuse failed: id=%d, old_client=%s, new_client=%s, err=closed", id, oldClientAddr, scon.RemoteAddr())
+		glog.Errorf("server=%s pair reuse failed: id=%d, old_client=%s, new_client=%s, err=closed", ss.typ, id, oldClientAddr, scon.RemoteAddr())
 		return false
 	}
 
-	glog.Infof("pair reuse: id=%d, old_client=%s, new_client=%s", id, oldClientAddr, scon.RemoteAddr())
+	glog.Infof("server=%s pair reuse: id=%d, old_client=%s, new_client=%s", ss.typ, id, oldClientAddr, scon.RemoteAddr())
 
 	connectionReuses.Inc()
 	return true
 }
 
-func newUpstreamConn(scon *scp.Conn) (conn net.Conn, err error) {
-	localconn, err := upstream.NewConn(scon)
+func (ss *SCPServer) newUpstreamConn(scon *scp.Conn) (conn net.Conn, err error) {
+	localconn, err := ss.upstreams.NewConn(scon)
 	if err != nil {
 		return
 	}
 	if scon, ok := localconn.(*scp.Conn); ok {
-		conn = NewLocalSCPConn(scon)
+		option := ss.option.Load().(*Option)
+		conn = NewLocalSCPConn(scon, option.SCPOption)
 	} else {
 		conn = localconn
 	}
@@ -183,24 +194,25 @@ func (ss *SCPServer) onNewConn(scon *scp.Conn) bool {
 	id := scon.ID()
 	defer ss.ReleaseID(id)
 
+	option := ss.option.Load().(*Option)
 	connPair := &connPair{}
-	connPair.RemoteConn = NewSCPConn(scon)
+	connPair.RemoteConn = NewSCPConn(scon, option.SCPOption)
 
 	// hold conn pair for reuse
 	ss.addConnPair(id, connPair)
 	defer ss.removeConnPair(id)
 
-	localConn, err := newUpstreamConn(scon)
+	localConn, err := ss.newUpstreamConn(scon)
 	if err != nil {
 		scon.Close()
 		upstreamErrors.Inc()
 
-		glog.Errorf("upstream new conn failed: id=%d, client=%s, err=%s", id, scon.RemoteAddr(), err.Error())
+		glog.Errorf("server=%s upstream new conn failed: id=%d, client=%s, err=%s", ss.typ, id, scon.RemoteAddr(), err.Error())
 		return false
 	}
 
 	connPair.LocalConn = localConn
-	connPair.Pump()
+	connPair.Pump(ss.typ)
 	return true
 }
 
@@ -215,12 +227,15 @@ func (ss *SCPServer) handleConn(conn net.Conn) {
 		}
 	}()
 
-	scon := scp.Server(conn, &scp.Config{ScpServer: ss})
-
+	option := ss.option.Load().(*Option)
+	scon := scp.Server(conn, &scp.Config{
+		ScpServer:        ss,
+		ReuseBufferSize:  option.SCPOption.ReuseBuffer,
+		HandshakeTimeout: option.SCPOption.HandshakeTimeout * time.Second})
 	err := scon.Handshake()
 
 	if err != nil {
-		glog.Errorf("scp handshake faield: client=%s, err=%s", conn.RemoteAddr().String(), err.Error())
+		glog.Errorf("scp handshake faield: server=%s, client=%s, err=%s", ss.typ, conn.RemoteAddr().String(), err.Error())
 		scon.Close()
 		metricOnHandshakeError(err)
 		return
@@ -234,9 +249,9 @@ func (ss *SCPServer) handleConn(conn net.Conn) {
 }
 
 // Serve accepts incoming connections on the Listener l
-func (ss *SCPServer) Serve(l net.Listener) error {
+func (ss *SCPServer) serve(l net.Listener) error {
 	addr := l.Addr().String()
-	glog.Infof("serve: addr=%s", addr)
+	glog.Infof("server=%s serve: addr=%s", ss.typ, addr)
 
 	var tempDelay time.Duration // how long to sleep on accept failure
 	for {
@@ -253,18 +268,125 @@ func (ss *SCPServer) Serve(l net.Listener) error {
 				if max := 1 * time.Second; tempDelay > max {
 					tempDelay = max
 				}
-				glog.Errorf("accept connection failed: addr=%s, err=%s, will retry in %v seconds", addr, err, tempDelay)
+				glog.Errorf("server=%s accept connection failed: addr=%s, err=%s, will retry in %v seconds", ss.typ, addr, err, tempDelay)
 				time.Sleep(tempDelay)
 				continue
 			}
-			glog.Errorf("accept failed: addr=%s, err=%s", addr, err.Error())
+			glog.Errorf("server=%s accept failed: addr=%s, err=%s", ss.typ, addr, err.Error())
 			return err
 		}
 		tempDelay = 0
 		if glog.V(1) {
-			glog.Infof("accept new connection: client=%s", conn.RemoteAddr())
+			glog.Infof("server=%s accept new connection: client=%s", ss.typ, conn.RemoteAddr())
 		}
 
 		go ss.handleConn(conn)
+	}
+}
+
+func (ss *SCPServer) listenTCP(listen string, option *TCPOption) error {
+	l, err := NewTCPListener(listen, option)
+	if err != nil {
+		return fmt.Errorf("listen tcp failed: addr=%s, err=%s", listen, err.Error())
+	}
+	glog.Infof("server=%s start listen tcp: addr=%s", ss.typ, listen)
+
+	ss.wg.Add(1)
+	ss.tcpListener = l
+	go func(l net.Listener) {
+		defer l.Close()
+		defer ss.wg.Done()
+		err := ss.serve(l)
+		glog.Errorf("server=%s stop listen tcp: addr=%s, err=%s", ss.typ, listen, err.Error())
+	}(l)
+	return nil
+}
+
+func (ss *SCPServer) listenKCP(listen string, option *KCPOption) error {
+	reuseport := option.ReusePort
+	if reuseport <= 0 {
+		reuseport = 1
+	}
+	for i := 0; i < reuseport; i++ {
+		l, err := NewKCPListener(listen, option)
+		if err != nil {
+			return fmt.Errorf("listen kcp failed: addr=%s, err=%s", listen, err.Error())
+		}
+		glog.Infof("server=%s start listen kcp: addr=%s", ss.typ, listen)
+
+		ss.wg.Add(1)
+		ss.kcpListeners = append(ss.kcpListeners, l)
+		go func(l net.Listener) {
+			defer l.Close()
+			defer ss.wg.Done()
+			err := ss.serve(l)
+			glog.Errorf("server=%s stop listen kcp: addr=%s, err=%s", ss.typ, listen, err.Error())
+		}(l)
+	}
+	return nil
+}
+
+// Listen listens scp over tcp or kcp.
+func (ss *SCPServer) Listen() error {
+	option := ss.option.Load().(*Option)
+	if option.TCP != "" {
+		if err := ss.listenTCP(option.TCP, option.TCPOption); err != nil {
+			return err
+		}
+	}
+	if option.KCP != "" {
+		if err := ss.listenKCP(option.KCP, option.KCPOption); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Done returns when all listeners closed.
+func (ss *SCPServer) Done() {
+	ss.wg.Wait()
+}
+
+func reloadAllServers() {
+	for typ, ss := range allServers {
+		option := GetConfigServerOption(typ)
+		if option != nil {
+			ss.option.Store(option)
+			if err := ss.upstreams.SetOption(option.UpstreamOption); err == nil {
+				ss.tcpListener.SetOption(option.TCPOption)
+				for _, kcpListener := range ss.kcpListeners {
+					kcpListener.SetOption(option.KCPOption)
+				}
+				glog.Infof("reload server=%s options", typ)
+			} else {
+				glog.Errorf("reload server=%s options failed", typ)
+			}
+		}
+	}
+}
+
+func startServer(typ string, option *Option) error {
+	u, err := upstream.New(option.UpstreamOption)
+	if err != nil {
+		return fmt.Errorf("start server=%s upstream failed, err=%s", typ, err.Error())
+	}
+
+	ss := &SCPServer{
+		typ:         typ,
+		idAllocator: scp.NewIDAllocator(1),
+		connPairs:   make(map[int]*connPair),
+		upstreams:   u,
+	}
+	ss.option.Store(option)
+	allServers[typ] = ss
+	if err := ss.Listen(); err != nil {
+		return fmt.Errorf("start server=%s listen failed, err=%s", typ, err.Error())
+	}
+	return nil
+}
+
+func allServerDone() {
+	for _, ss := range allServers {
+		ss.Done()
 	}
 }

--- a/server.go
+++ b/server.go
@@ -339,12 +339,10 @@ func (ss *SCPServer) Listen() error {
 		if err := ss.listenTCP(option.Listen, option.TCPOption); err != nil {
 			return err
 		}
-		break
 	case "kcp":
 		if err := ss.listenKCP(option.Listen, option.KCPOption); err != nil {
 			return err
 		}
-		break
 	}
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -354,6 +354,7 @@ func (ss *SCPServer) Done() {
 
 func newReuseBufferPool(cap int) *scp.LoopBufferPool {
 	return &scp.LoopBufferPool{
+		Cap: cap,
 		Pool: sync.Pool{
 			New: func() interface{} {
 				return scp.NewLoopBuffer(cap)
@@ -375,11 +376,14 @@ func reloadAllServers() {
 			} else {
 				glog.Errorf("reload server=%s options failed", typ)
 			}
-			reuseBufferPool := newReuseBufferPool(option.SCPOption.ReuseBuffer)
 
 			// ensure no error below.
 			ss.option.Store(option)
-			ss.reuseBufferPool.Store(reuseBufferPool)
+			oldReuseBufferPool := ss.reuseBufferPool.Load().(*scp.LoopBufferPool)
+			if oldReuseBufferPool.Cap != option.SCPOption.ReuseBuffer {
+				reuseBufferPool := newReuseBufferPool(option.SCPOption.ReuseBuffer)
+				ss.reuseBufferPool.Store(reuseBufferPool)
+			}
 		}
 	}
 }

--- a/server_option.go
+++ b/server_option.go
@@ -41,10 +41,10 @@ type KCPOption struct {
 
 // Option configs server option.
 type Option struct {
-	TCP            string           `mapstructure:"tcp"`
-	KCP            string           `mapstructure:"kcp"`
-	TCPOption      *TCPOption       `mapstructure:"tcp_option"`
-	KCPOption      *KCPOption       `mapstructure:"kcp_option"`
-	SCPOption      *SCPOption       `mapstructure:"scp_option"`
-	UpstreamOption *upstream.Option `mapstructure:"upstream_option"`
+	Listen    string           `mapstructure:"listen"`
+	Net       string           `mapstructure:"net"`
+	TCPOption *TCPOption       `mapstructure:"tcp_option"`
+	KCPOption *KCPOption       `mapstructure:"kcp_option"`
+	SCPOption *SCPOption       `mapstructure:"scp_option"`
+	Upstream  *upstream.Option `mapstructure:"upstream"`
 }

--- a/server_option.go
+++ b/server_option.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"time"
+
+	"github.com/ejoy/goscon/upstream"
+)
+
+// SCPOption configs scp option.
+type SCPOption struct {
+	HandshakeTimeout time.Duration `mapstructure:"handshake_timeout"`
+	ReuseTime        time.Duration `mapstructure:"reuse_time"`
+	ReuseBuffer      int           `mapstructure:"reuse_buffer"`
+}
+
+// TCPOption configs tcp option.
+type TCPOption struct {
+	ReadTimeout       time.Duration `mapstructure:"read_timeout"`
+	Keepalive         bool          `mapstructure:"keepalive"`
+	KeepaliveInterval time.Duration `mapstructure:"keepalive_interval"`
+}
+
+// KCPOption configs kcp option.
+type KCPOption struct {
+	ReusePort       int           `mapstructure:"reuseport"`
+	ReadTimeout     time.Duration `mapstructure:"read_timeout"`
+	FecDataShards   int           `mapstructure:"fec_data_shards"`
+	FecParityShards int           `mapstructure:"fec_parity_shards"`
+	ReadBuffer      int           `mapstructure:"read_buffer"`
+	WriteBuffer     int           `mapstructure:"write_buffer"`
+	OptMTU          int           `mapstructure:"opt_mtu"`
+	OptNodelay      int           `mapstructure:"opt_nodelay"`
+	OptInterval     int           `mapstructure:"opt_interval"`
+	OptResend       int           `mapstructure:"opt_resend"`
+	OptNC           int           `mapstructure:"opt_nc"`
+	OptSndwnd       int           `mapstructure:"opt_sndwnd"`
+	OptRcvwnd       int           `mapstructure:"opt_rcvwnd"`
+	OptStream       bool          `mapstructure:"opt_stream"`
+	OptWriteDelay   bool          `mapstructure:"opt_writedelay"`
+}
+
+// Option configs server option.
+type Option struct {
+	TCP            string           `mapstructure:"tcp"`
+	KCP            string           `mapstructure:"kcp"`
+	TCPOption      *TCPOption       `mapstructure:"tcp_option"`
+	KCPOption      *KCPOption       `mapstructure:"kcp_option"`
+	SCPOption      *SCPOption       `mapstructure:"scp_option"`
+	UpstreamOption *upstream.Option `mapstructure:"upstream_option"`
+}

--- a/upstream/resolv.go
+++ b/upstream/resolv.go
@@ -1,0 +1,131 @@
+package upstream
+
+import (
+	"errors"
+	"net"
+	"regexp"
+	"sync/atomic"
+)
+
+// Name resolve search the hosts firstly,
+// then search by the resolve rule if `resolv` is true.
+
+var errInvalidHost = errors.New("invalid hosts config")
+var errNoPort = errors.New("no port")
+
+var (
+	configHosts   atomic.Value // []*Hosts
+	configHostMap atomic.Value // map[string]*resolveResult
+	configResolv  atomic.Value // ResolveRule
+)
+
+type resolveResult struct {
+	hosts []*Host
+}
+
+// Host indicates a backend server
+type Host struct {
+	Name string
+	Addr string // hostport address, and host must be ip.
+
+	addr *net.TCPAddr
+}
+
+// Normalize .
+func (h *Host) Normalize() error {
+	host, service, err := net.SplitHostPort(h.Addr)
+	if err != nil {
+		return err
+	}
+	if net.ParseIP(host) == nil {
+		return errInvalidHost
+	}
+	if addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, service)); err != nil {
+		return err
+	} else {
+		h.addr = addr
+	}
+	return nil
+}
+
+// ResolveRule describes upstream resolver config
+type ResolveRule struct {
+	// prefix + name + suffix provides the domain name.
+	Prefix string
+	Suffix string
+
+	Port string
+
+	// The `targetServer` name must match the pattern.
+	Pattern   string
+	rePattern *regexp.Regexp
+}
+
+// Normalize .
+func (r *ResolveRule) Normalize() error {
+	if r.Pattern != "" {
+		rePattern, err := regexp.Compile(r.Pattern)
+		if err != nil {
+			return err
+		}
+		r.rePattern = rePattern
+	}
+	if r.Port == "" {
+		return errNoPort
+	}
+	return nil
+}
+
+// FullName returns hostport defined by rule.
+func (r *ResolveRule) FullName(name string) string {
+	return net.JoinHostPort(r.Prefix+name+r.Suffix, r.Port)
+}
+
+// Validate validates the `targetServer` name.
+func (r *ResolveRule) Validate(name string) bool {
+	if r.rePattern == nil {
+		return true
+	}
+	return r.rePattern.MatchString(name)
+}
+
+// 1. Search the local host map firstly.
+// 2. Search based on the resolv rule.
+func resolvName(name string, resolv bool) []*Host {
+	hostMap := configHostMap.Load().(map[string]*resolveResult)
+	if rr, exist := hostMap[name]; exist {
+		return rr.hosts
+	}
+	hosts := make([]*Host, 0, 2)
+	rule := configResolv.Load().(*ResolveRule)
+	if rule.Validate(name) {
+		hostport := rule.FullName(name)
+		if addr, err := net.ResolveTCPAddr("tcp", hostport); err == nil {
+			hosts = append(hosts, &Host{Name: name, Addr: hostport, addr: addr})
+		}
+	}
+	if len(hosts) == 0 {
+		return nil
+	}
+	return hosts
+}
+
+// ReloadHosts reloads the global hosts config.
+func ReloadHosts(hosts []*Host) {
+	hostMap := make(map[string]*resolveResult)
+	for _, h := range hosts {
+		if _, e := hostMap[h.Name]; !e {
+			hostMap[h.Name] = new(resolveResult)
+		}
+		rr := hostMap[h.Name]
+		rr.hosts = append(rr.hosts, h)
+	}
+
+	configHosts.Store(hosts)
+	configHostMap.Store(hostMap)
+}
+
+// ReloadResolv reloads the global resolv config.
+func ReloadResolv(resolv *ResolveRule) {
+	configResolv.Store(resolv)
+}

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -15,22 +15,22 @@ var ErrNoHost = errors.New("no host")
 
 const defaultWeight = 100
 
-// Location .
-type Location struct {
+// Server .
+type Server struct {
 	Name   string
 	Weight int
 }
 
 // Option describes upstream option.
 // `Net` indicates the protocol to use for upstream connection.
-// `Locations` is where the scon will be routed to when `TargetServer` is not assigned.
+// `Servers` is where the scon will be routed to when `TargetServer` is not assigned.
 // `Resolv` is true indicates that using the `Resolv` rule for name resolv.
 type Option struct {
 	Net    string
 	Resolv bool
 
-	Locations []*Location
-	Weight    int
+	Servers []*Server
+	Weight  int
 }
 
 // Upstreams 代表后端服务
@@ -40,7 +40,7 @@ type Upstreams struct {
 
 // SetOption .
 func (u *Upstreams) SetOption(option *Option) error {
-	for _, h := range option.Locations {
+	for _, h := range option.Servers {
 		if h.Weight <= 0 {
 			h.Weight = defaultWeight
 		}
@@ -50,8 +50,8 @@ func (u *Upstreams) SetOption(option *Option) error {
 	return nil
 }
 
-func chooseByWeight(locations []*Location, weight int) string {
-	if len(locations) == 0 {
+func chooseByWeight(servers []*Server, weight int) string {
+	if len(servers) == 0 {
 		return ""
 	}
 	if weight == 0 {
@@ -59,7 +59,7 @@ func chooseByWeight(locations []*Location, weight int) string {
 	}
 
 	v := rand.Intn(weight)
-	for _, l := range locations {
+	for _, l := range servers {
 		if l.Weight >= v {
 			return l.Name
 		}
@@ -74,10 +74,10 @@ func (u *Upstreams) GetPreferredHost(name string) []*Host {
 	return resolvName(name, option.Resolv)
 }
 
-// GetRandomHost chooses hosts randomly from all locations.
+// GetRandomHost chooses hosts randomly from all servers.
 func (u *Upstreams) GetRandomHost() []*Host {
 	option := u.option.Load().(*Option)
-	name := chooseByWeight(option.Locations, option.Weight)
+	name := chooseByWeight(option.Servers, option.Weight)
 	return resolvName(name, option.Resolv)
 }
 

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"math/rand"
 	"net"
-	"regexp"
 	"sync/atomic"
 
 	"github.com/ejoy/goscon/scp"
@@ -16,223 +15,85 @@ var ErrNoHost = errors.New("no host")
 
 const defaultWeight = 100
 
-// ResolveRule describes upstream resolver config
-type ResolveRule struct {
-	// prefix + name + suffix provides the domain name.
-	Prefix string
-	Suffix string
-
-	Port string
-
-	// The `targetServer` name must match the pattern.
-	Pattern   string
-	rePattern *regexp.Regexp
+// Location .
+type Location struct {
+	Name   string
+	Weight int
 }
 
-var errNoPort = errors.New("no port")
-
-// Normalize .
-func (r *ResolveRule) Normalize() error {
-	if r.Pattern != "" {
-		rePattern, err := regexp.Compile(r.Pattern)
-		if err != nil {
-			return err
-		}
-		r.rePattern = rePattern
-	}
-	if r.Port == "" {
-		return errNoPort
-	}
-	return nil
-}
-
-// FullName returns hostport defined by rule.
-func (r *ResolveRule) FullName(name string) string {
-	return net.JoinHostPort(r.Prefix+name+r.Suffix, r.Port)
-}
-
-// Validate validates the `targetServer` name.
-func (r *ResolveRule) Validate(name string) bool {
-	if r.rePattern == nil {
-		return true
-	}
-	return r.rePattern.MatchString(name)
-}
-
-// Option describes upstream option
+// Option describes upstream option.
+// `Net` indicates the protocol to use for upstream connection.
+// `Locations` is where the scon will be routed to when `TargetServer` is not assigned.
+// `Resolv` is true indicates that using the `Resolv` rule for name resolv.
 type Option struct {
 	Net    string
-	Resolv *ResolveRule
+	Resolv bool
 
-	Hosts []*Host
-}
-
-// Host indicates a backend server
-type Host struct {
-	Name   string
-	Addr   string
-	Weight int
-
-	addrs []*net.TCPAddr
-}
-
-type hostGroup struct {
-	hosts  []*Host
-	weight int
+	Locations []*Location
+	Weight    int
 }
 
 // Upstreams 代表后端服务
 type Upstreams struct {
 	option atomic.Value // *Option
-
-	allHosts    atomic.Value // *hostGroup
-	byNameHosts atomic.Value // map[string]*hostGroup
-}
-
-// GetOption returns upstreams option.
-func (u *Upstreams) GetOption() *Option {
-	return u.option.Load().(*Option)
-}
-
-// reference to the host:port format of `net.Dial`.
-func lookupTCPAddrs(hostport string) ([]*net.TCPAddr, error) {
-	host, service, err := net.SplitHostPort(hostport)
-	if err != nil {
-		return nil, err
-	}
-	addrs, err := net.LookupHost(host)
-	if err != nil {
-		return nil, err
-	}
-	tcpAddrs := make([]*net.TCPAddr, len(addrs))
-	for i, addr := range addrs {
-		addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(addr, service))
-		if err != nil { // only error when lookup port failed
-			return nil, err
-		}
-		tcpAddrs[i] = addr
-	}
-	return tcpAddrs, nil
 }
 
 // SetOption .
 func (u *Upstreams) SetOption(option *Option) error {
-	// normalize resolv rule.
-	if option.Resolv != nil {
-		option.Resolv.Normalize()
-	}
-
-	// initialize the hosts.
-	hosts := option.Hosts
-	sz := len(hosts)
-	allHosts := new(hostGroup)
-	allHosts.hosts = make([]*Host, 0, sz)
-	allHosts.weight = 0
-
-	byNameHosts := make(map[string]*hostGroup)
-	for _, host := range hosts {
-		h := host
-		addrs, err := lookupTCPAddrs(h.Addr)
-		if err != nil {
-			return err
-		}
-		h.addrs = addrs
+	for _, h := range option.Locations {
 		if h.Weight <= 0 {
-			// set default weight
 			h.Weight = defaultWeight
 		}
-		allHosts.hosts = append(allHosts.hosts, h)
-		allHosts.weight = allHosts.weight + h.Weight
-
-		if h.Name != "" {
-			hg := byNameHosts[h.Name]
-			if hg == nil {
-				hg = new(hostGroup)
-				byNameHosts[h.Name] = hg
-			}
-			hg.hosts = append(hg.hosts, h)
-			hg.weight = hg.weight + h.Weight
-		}
+		option.Weight += h.Weight
 	}
-
 	u.option.Store(option)
-	u.allHosts.Store(allHosts)
-	u.byNameHosts.Store(byNameHosts)
-
 	return nil
 }
 
-func chooseByLocalHosts(group *hostGroup) *Host {
-	if group == nil || len(group.hosts) == 0 {
-		return nil
+func chooseByWeight(locations []*Location, weight int) string {
+	if len(locations) == 0 {
+		return ""
+	}
+	if weight == 0 {
+		return ""
 	}
 
-	v := rand.Intn(group.weight)
-	for _, host := range group.hosts {
-		if host.Weight >= v {
-			return host
+	v := rand.Intn(weight)
+	for _, l := range locations {
+		if l.Weight >= v {
+			return l.Name
 		}
-		v -= host.Weight
+		v -= l.Weight
 	}
-	return nil
+	return ""
 }
 
-func chooseByResolver(name string, rule *ResolveRule) *Host {
-	hosts := make([]*Host, 0, 2)
-	if rule.Validate(name) {
-		hostport := rule.FullName(name)
-		addrs, err := lookupTCPAddrs(hostport)
-		if err == nil {
-			h := Host{
-				Name:  name,
-				Addr:  hostport,
-				addrs: addrs,
-			}
-			hosts = append(hosts, &h)
-		}
-	}
-	lenhosts := len(hosts)
-	if lenhosts == 0 {
-		return nil
-	}
-	return hosts[rand.Intn(lenhosts)]
-}
-
-// GetPreferredHost choose a host by name.
-// If several hosts have same name then random choose by weight
-func (u *Upstreams) GetPreferredHost(name string) *Host {
-	mapHosts := u.byNameHosts.Load().(map[string]*hostGroup)
-	h := chooseByLocalHosts(mapHosts[name])
-	if h != nil {
-		return h
-	}
+// GetPreferredHost choose hosts by name.
+func (u *Upstreams) GetPreferredHost(name string) []*Host {
 	option := u.option.Load().(*Option)
-	if option.Resolv != nil {
-		h = chooseByResolver(name, option.Resolv)
-	}
-	if h == nil {
-		glog.Errorf("prefered name is malformed, name=%s", name)
-	}
-	return h
+	return resolvName(name, option.Resolv)
 }
 
-// GetRandomHost chooses a host randomly from all hosts.
-func (u *Upstreams) GetRandomHost() *Host {
-	mapHosts := u.allHosts.Load().(*hostGroup)
-	return chooseByLocalHosts(mapHosts)
+// GetRandomHost chooses hosts randomly from all locations.
+func (u *Upstreams) GetRandomHost() []*Host {
+	option := u.option.Load().(*Option)
+	name := chooseByWeight(option.Locations, option.Weight)
+	return resolvName(name, option.Resolv)
 }
 
 // GetHost prefers static hosts map, and will use resolver if config.
 // When preferred is empty string, GetHost only searches static hosts map.
 func (u *Upstreams) GetHost(preferred string) *Host {
-	var h *Host
+	var hosts []*Host
 	if preferred != "" {
-		h = u.GetPreferredHost(preferred)
+		hosts = u.GetPreferredHost(preferred)
+	} else {
+		hosts = u.GetRandomHost()
 	}
-	if h == nil {
-		h = u.GetRandomHost()
+	if len(hosts) > 0 {
+		return hosts[rand.Intn(len(hosts))]
 	}
-	return h
+	return nil
 }
 
 func upgradeConn(network string, localConn net.Conn, remoteConn *scp.Conn) (conn net.Conn, err error) {
@@ -268,8 +129,7 @@ func (u *Upstreams) NewConn(remoteConn *scp.Conn) (conn net.Conn, err error) {
 		return
 	}
 
-	addr := host.addrs[rand.Intn(len(host.addrs))]
-	tcpConn, err := net.DialTCP("tcp", nil, addr)
+	tcpConn, err := net.DialTCP("tcp", nil, host.addr)
 	if err != nil {
 		glog.Errorf("connect to <%s> failed: %s", host.Addr, err.Error())
 		return

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -238,9 +238,12 @@ func (u *Upstreams) GetHost(preferred string) *Host {
 func upgradeConn(network string, localConn net.Conn, remoteConn *scp.Conn) (conn net.Conn, err error) {
 	if network == "scp" {
 		scon, _ := scp.Client(localConn, &scp.Config{
-			TargetServer:    remoteConn.TargetServer(),
-			Flag:            scp.SCPFlagForbidForwardIP,
+			Flag: scp.SCPFlagForbidForwardIP,
+
+			TargetServer: remoteConn.TargetServer(),
+			// Keeps ReuseBuffer consistent with the remote conn (downstream).
 			ReuseBufferSize: remoteConn.ReuseBufferSize(),
+			ReuseBufferPool: remoteConn.ReuseBufferPool(),
 		})
 
 		err = scon.Handshake()


### PR DESCRIPTION
配置支持多监听服务器。

- 新增配置项
其中 resolv / hosts 规则调整为共享配置，支持所有 server 共享使用，类似于 /etc/hosts 和 /etc/resolv。
对于名字查找，优先查找 hosts，再使用 resolv 进一步查找。

- 关于查找的规则
  对于 server，增加 locations 配置项替代原有 hosts 配置，指示可连接的后端服务器，仅 `TargetServer` 为空时会在 location 中按权重查找到特定名字。
  
  对于 TargetServer 非空时，类似于域名解析流程。